### PR TITLE
test: create test nested structure for better output

### DIFF
--- a/dog/directory_test.go
+++ b/dog/directory_test.go
@@ -9,48 +9,47 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDirectoryShouldReturnRecursiveDirs(t *testing.T) {
-	entryDir, _ := ioutil.TempDir("", "")
-	nestedDir, _ := ioutil.TempDir(entryDir, "")
-	nestedDir2, _ := ioutil.TempDir(nestedDir, "")
-	ioutil.TempFile(entryDir, "")
-	ignoreDir, _ := ioutil.TempDir(entryDir, "")
+func TestDirectoryShould(t *testing.T) {
+	t.Run("ReturnRecursiveDirs", func(t *testing.T) {
+		entryDir, _ := ioutil.TempDir("", "")
+		nestedDir, _ := ioutil.TempDir(entryDir, "")
+		nestedDir2, _ := ioutil.TempDir(nestedDir, "")
+		ioutil.TempFile(entryDir, "")
+		ignoreDir, _ := ioutil.TempDir(entryDir, "")
 
-	ignores := make(map[string]struct{})
-	ignores[ignoreDir] = struct{}{}
-	helper := NewDirectory(entryDir, ignores)
-	dirs, _ := helper.GetDirs()
+		ignores := make(map[string]struct{})
+		ignores[ignoreDir] = struct{}{}
+		helper := NewDirectory(entryDir, ignores)
+		dirs, _ := helper.GetDirs()
 
-	for _, dir := range []string{entryDir, nestedDir, nestedDir2} {
-		assert.Contains(t, dirs, dir)
-	}
-	assert.NotContains(t, dirs, ignoreDir)
-	os.RemoveAll(entryDir)
-}
-
-func TestDirectoryShouldIgnoreWildcardExtension(t *testing.T) {
-	ignores := make(map[string]struct{})
-	ignores["*.swp"] = struct{}{}
-	helper := NewDirectory(".", ignores)
-	if !helper.IsIgnoreFile("README.md.swp") {
-		t.Error("should ignore README.md.swp")
-	}
-}
-
-func TestDirectoryShouldIgnoreWildcardEndsWith(t *testing.T) {
-	ignores := make(map[string]struct{})
-	ignores["*~"] = struct{}{}
-	helper := NewDirectory(".", ignores)
-	if !helper.IsIgnoreFile("README.md~") {
-		t.Error("should ignore README.md~")
-	}
-}
-
-func TestDirectoryShouldIgnoreNestedWildcardExtension(t *testing.T) {
-	ignores := make(map[string]struct{})
-	ignores["*.swp"] = struct{}{}
-	helper := NewDirectory(".", ignores)
-	if !helper.IsIgnoreFile("doc/README.md.swp") {
-		t.Error("should ignore README.md.swp")
-	}
+		for _, dir := range []string{entryDir, nestedDir, nestedDir2} {
+			assert.Contains(t, dirs, dir)
+		}
+		assert.NotContains(t, dirs, ignoreDir)
+		os.RemoveAll(entryDir)
+	})
+	t.Run("IgnoreWildcardExtension", func(t *testing.T) {
+		ignores := make(map[string]struct{})
+		ignores["*.swp"] = struct{}{}
+		helper := NewDirectory(".", ignores)
+		if !helper.IsIgnoreFile("README.md.swp") {
+			t.Error("should ignore README.md.swp")
+		}
+	})
+	t.Run("IgnoreWildcardEndsWith", func(t *testing.T) {
+		ignores := make(map[string]struct{})
+		ignores["*~"] = struct{}{}
+		helper := NewDirectory(".", ignores)
+		if !helper.IsIgnoreFile("README.md~") {
+			t.Error("should ignore README.md~")
+		}
+	})
+	t.Run("IgnoreNestedWildcardExtension", func(t *testing.T) {
+		ignores := make(map[string]struct{})
+		ignores["*.swp"] = struct{}{}
+		helper := NewDirectory(".", ignores)
+		if !helper.IsIgnoreFile("doc/README.md.swp") {
+			t.Error("should ignore README.md.swp")
+		}
+	})
 }


### PR DESCRIPTION
OUTPUT:

```
=== RUN   TestCommandShouldExecute
--- PASS: TestCommandShouldExecute (0.00s)
=== RUN   TestReExecuteShouldReExecuteAndCancelPreviousCommand
--- PASS: TestReExecuteShouldReExecuteAndCancelPreviousCommand (0.00s)
=== RUN   TestDirectoryShould
=== RUN   TestDirectoryShould/ReturnRecursiveDirs
1
=== RUN   TestDirectoryShould/IgnoreWildcardExtension
=== RUN   TestDirectoryShould/IgnoreWildcardEndsWith
=== RUN   TestDirectoryShould/IgnoreNestedWildcardExtension
--- PASS: TestDirectoryShould (0.00s)
    --- PASS: TestDirectoryShould/ReturnRecursiveDirs (0.00s)
    --- PASS: TestDirectoryShould/IgnoreWildcardExtension (0.00s)
    --- PASS: TestDirectoryShould/IgnoreWildcardEndsWith (0.00s)
    --- PASS: TestDirectoryShould/IgnoreNestedWildcardExtension (0.00s)
PASS
1
ok      github.com/shana0440/watchdog/dog       0.019s
```

Can see nested is more readable than normal version